### PR TITLE
Add Hardhat tasks to Manage Orakl Network Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cp .env.example .env
 ```
 
 `PROVIDER` can be set to any JSON-RPC endpoint.
-The list of free available JSON-RPC endpoint can be found in [official Klaytn documentation](https://docs.klaytn.foundation/content/dapp/json-rpc/public-en#testnet-baobab-public-json-rpc-endpoints).
+The list of free available JSON-RPC endpoint can be found in [official Klaytn documentation](https://docs.klaytn.foundation/content/dapp/rpc-service/public-en#testnet-baobab-public-json-rpc-endpoints).
 
 This repository supports connection to wallet either through mnemonic or private key.
 
@@ -41,7 +41,6 @@ If you do not have any KLAY in your account, you cannot deploy smart contracts o
 You can convert your newly generated mnemonic with following hardhat task.
 
 Please replace the `MNENONIC` with your mnemonic and run the command below.
-
 
 ```shell
 npx hardhat address --mnemonic ${MNEMONIC}
@@ -113,4 +112,56 @@ npx hardhat run scripts/request-data-direct.ts --network baobab
 
 ```shell
 npx hardhat run scripts/read-response.ts --network baobab
+```
+
+## Hardhat Tasks
+
+### Create new account
+
+```shell
+npx hardhat createAccount --network baobab
+```
+
+### Deposit to account
+
+After you have created an account, you can deposit $KLAY to it anytime using the command below.
+
+```shell
+npx hardhat deposit \
+    --account-id $ACCOUNT \
+    --amount $AMOUNT \
+    --network $NETWORK
+```
+
+### Withdraw from account
+
+To withdraw the remaining balance from account, you can use the command below.
+
+```shell
+npx hardhat withdraw \
+    --account-id $ACCOUNT \
+    --amount $AMOUNT \
+    --network $NETWORK
+```
+
+### Add consumer
+
+Add consumer contract to account. Then, consumer contract will be able to request for Request Responce service.
+
+```shell
+npx hardhat addConsumer \
+    --consumer $CONSUMERADDRESS \
+    --account-id $ACCOUNT \
+    --network $NETWORK
+```
+
+### Remove consumer
+
+Remove consumer contract from account. Then, consumer contract will not be able to request for Request Responce service anymore.
+
+```shell
+npx hardhat removeConsumer \
+    --consumer ${CONSUMERADDRESS} \
+    --account-id ${ACCOUNT} \
+    --network ${NETWORK}
 ```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,6 +4,7 @@ import '@nomiclabs/hardhat-web3'
 import '@nomiclabs/hardhat-ethers'
 import 'hardhat-deploy'
 import dotenv from 'dotenv'
+import { Prepayment__factory } from '@bisonai/orakl-contracts'
 
 dotenv.config()
 
@@ -68,6 +69,98 @@ task('address', 'Convert mnemonic to address')
   .setAction(async (taskArgs, hre) => {
     const wallet = hre.ethers.Wallet.fromMnemonic(taskArgs.mnemonic)
     console.log(wallet.address)
+  })
+
+task('createAccount', 'Create new account').setAction(async (taskArgs, hre) => {
+  const { prepayment: prepaymentAddress } = await hre.getNamedAccounts()
+  const prepayment = await ethers.getContractAt(Prepayment__factory.abi, prepaymentAddress)
+
+  const txReceipt = await (await prepayment.createAccount()).wait()
+  const accId = txReceipt.events[0].args.accId.toString()
+
+  console.log(`Account created with ID: ${accId}`)
+})
+
+task('deposit', 'Deposit $KLAY to account')
+  .addParam('amount', 'The amount of $KLAY')
+  .addOptionalParam('accountId', 'Account Id')
+  .setAction(async (taskArgs, hre) => {
+    const accId = taskArgs.accountId || process.env.ACC_ID
+    const klayAmount = taskArgs.amount
+
+    if (accId) {
+      const { prepayment: prepaymentAddress } = await hre.getNamedAccounts()
+      const prepayment = await ethers.getContractAt(Prepayment__factory.abi, prepaymentAddress)
+      const amount = ethers.utils.parseEther(klayAmount)
+      const txReceipt = await (await prepayment.deposit(accId, { value: amount })).wait()
+      const balance = txReceipt.events[0].args.newBalance.toString()
+      const newBalance = ethers.utils.formatEther(balance)
+
+      console.log(`Deposited ${klayAmount} $KLAY to account ${accId}`)
+      console.log(`Account balance after deposit: ${newBalance} $KLAY`)
+    } else {
+      console.log(`Prepayment accountId is not defined`)
+    }
+  })
+
+task('withdraw', 'Withdraw $KLAY from account')
+  .addParam('amount', 'The amount of $KLAY')
+  .addOptionalParam('accountId', 'Account Id')
+  .setAction(async (taskArgs, hre) => {
+    const accId = taskArgs.accountId || process.env.ACC_ID
+    const klayAmount = taskArgs.amount
+
+    if (accId) {
+      const { prepayment: prepaymentAddress } = await hre.getNamedAccounts()
+      const prepayment = await ethers.getContractAt(Prepayment__factory.abi, prepaymentAddress)
+      const amount = ethers.utils.parseEther(klayAmount)
+      const txReceipt = await (await prepayment.withdraw(accId, amount)).wait()
+      const balance = txReceipt.events[0].args.newBalance.toString()
+      const newBalance = ethers.utils.formatEther(balance)
+
+      console.log(`Withdrew ${klayAmount} $KLAY to account ${accId}`)
+      console.log(`Account balance after withdrawal: ${newBalance} $KLAY`)
+    } else {
+      console.log(`Prepayment accountId is not defined`)
+    }
+  })
+
+task('addConsumer', 'Add consumer')
+  .addParam('consumer', 'Consumer Address')
+  .addOptionalParam('accountId', 'Account Id')
+  .setAction(async (taskArgs, hre) => {
+    const accId = taskArgs.accountId || process.env.ACC_ID
+    const consumerAddress = taskArgs.consumer || (await ethers.getContract('VRFConsumer')).address
+
+    if (accId && consumerAddress) {
+      const { prepayment: prepaymentAddress } = await hre.getNamedAccounts()
+      const prepayment = await ethers.getContractAt(Prepayment__factory.abi, prepaymentAddress)
+      await (await prepayment.addConsumer(accId, consumerAddress)).wait()
+
+      console.log(`Added consumer ${consumerAddress} to prepayment account`)
+    } else {
+      if (!accId) console.log(`Prepayment accountId is not defined`)
+      if (!consumerAddress) console.log(`Consumer Address is not defined`)
+    }
+  })
+
+task('removeConsumer', 'Remove consumer')
+  .addParam('consumer', 'Consumer Address')
+  .addOptionalParam('accountId', 'Account Id')
+  .setAction(async (taskArgs, hre) => {
+    const accId = taskArgs.accountId || process.env.ACC_ID
+    const consumerAddress = taskArgs.consumer || (await ethers.getContract('VRFConsumer')).address
+
+    if (accId && consumerAddress) {
+      const { prepayment: prepaymentAddress } = await hre.getNamedAccounts()
+      const prepayment = await ethers.getContractAt(Prepayment__factory.abi, prepaymentAddress)
+      await (await prepayment.removeConsumer(accId, consumerAddress)).wait()
+
+      console.log(`Removed consumer ${consumerAddress} to prepayment account`)
+    } else {
+      if (!accId) console.log(`Prepayment accountId is not defined`)
+      if (!consumerAddress) console.log(`Consumer Address is not defined`)
+    }
   })
 
 export default config


### PR DESCRIPTION
This PR is identical with change on [vrf-consumer](https://github.com/Bisonai/vrf-consumer/pull/12) which addes hardhat tasks to make easy commands with `Orakl Network Accounts `

List of hardhat tasks:
- `createAccount`
- `deposit`
- `withdraw`
- `addConsumer`
- `removeConsumer`

Resolve Issues:

- https://github.com/Bisonai/orakl/issues/512
- https://github.com/Bisonai/orakl/issues/511